### PR TITLE
fixed error 'pub.on is not a function'

### DIFF
--- a/src/hooks/usePublish.ts
+++ b/src/hooks/usePublish.ts
@@ -33,9 +33,7 @@ const usePublish = (relays: string[], privateKey?: string) => {
 
           const pub = pool.publish(relays, signedEvent);
 
-          pub.on('ok', () => {
-            resolve(signedEvent);
-          });
+          resolve(signedEvent);
         } catch (error) {
           reject(error);
         }


### PR DESCRIPTION
this error occurs with new version of nostr-tools as the api has been changed. See: https://github.com/nbd-wtf/nostr-tools/pull/263

we don't have to check for ok status anymore