### PR TITLE
Allow users to import types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 package-lock.json
+pnpm-lock.yaml
 dist

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './hooks';
+export * from './types';


### PR DESCRIPTION
I'm running into an issue inside a TypeScript React app where I can not access the types used in this package. I believe that the change I'm suggesting which simply exports the types file should allow me to do the following without getting the error.

## Expected this to work:
`import { Filter, useSubscribe } from 'nostr-hooks';`

## But it result is a TypeScript syntax error:
`Module '"nostr-hooks"' has no exported member 'Filter'.ts(2305)`

## Current workaround:
Install `nostr-tools` , import the type from there instead, and manually define the `Options` and `Config` types:
```
import { Filter } from 'nostr-tools';

export interface Config {
    filters: Filter[];
    relays: string[];
    options?: Options | undefined;
}
export interface Options {
    batchingInterval?: number | undefined;
    enabled?: boolean | undefined;
    force?: boolean | undefined;
    invalidate?: boolean | undefined;
    closeAfterEose?: boolean | undefined;
    cacheRefresh?: boolean | undefined;
}
```