### PR TITLE
Swap out signEvent for getSignature

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,7 +6,7 @@ import {
   UnsignedEvent,
   getEventHash,
   getPublicKey,
-  signEvent,
+  getSignature,
 } from 'nostr-tools';
 
 export const generateSubId = () => {
@@ -32,7 +32,7 @@ export const signEventWithPrivateKey = (eventTemplate: EventTemplate, privateKey
   const signedEvent: Event = {
     ...unsignedEvent,
     id: getEventHash(unsignedEvent),
-    sig: signEvent(unsignedEvent, privateKey),
+    sig: getSignature(unsignedEvent, privateKey),
   };
 
   return signedEvent;


### PR DESCRIPTION
The `nostr-tools` `signEvent` function is deprecated and will be removed at some point in the future.

https://github.com/nbd-wtf/nostr-tools/blob/40c5337ef0b8eb47e126d721408e7798735dd06e/event.ts#L133